### PR TITLE
'fix' quoted string regexp

### DIFF
--- a/Drools_Syntax_Highlighter/SublimeText_3/Drools.JSON-tmLanguage
+++ b/Drools_Syntax_Highlighter/SublimeText_3/Drools.JSON-tmLanguage
@@ -53,7 +53,7 @@
 			"comment": "Multi line comment"
 		},
 		{
-			"match": "(\").*(\")",
+			"match": "(\")[^\"]*(\")",
 			"name": "string.quoted.double.source.drools",
 			"comment": "Double quote strings"
 		},

--- a/Drools_Syntax_Highlighter/SublimeText_3/Drools.tmLanguage
+++ b/Drools_Syntax_Highlighter/SublimeText_3/Drools.tmLanguage
@@ -80,7 +80,7 @@
 			<key>comment</key>
 			<string>Double quote strings</string>
 			<key>match</key>
-			<string>(").*(")</string>
+			<string>(")[^"]*(")</string>
 			<key>name</key>
 			<string>string.quoted.double.source.drools</string>
 		</dict>


### PR DESCRIPTION
Fix quoted string highlighting.

(Won't work if the string contains an escaped quote. We should use a proper parser for that.)